### PR TITLE
Attempt build with AUDIO_MODE first.

### DIFF
--- a/dist/aish.srpm.spec
+++ b/dist/aish.srpm.spec
@@ -24,7 +24,8 @@ this at your own risk and not in production. AI can produce unexpected results.
 %autosetup
 
 %build
-make -j
+# Try with AUDIO_MODE first. BuildRequires still fails if festivel-devel isn't available.
+CFLAGS="-DAUDIO_MODE" make -j || make -j
 
 %install
 mkdir -p %{buildroot}%{_bindir}/


### PR DESCRIPTION
Some distros don't support the festival package or festival-devel so build fails with audio mode and deps. Unfortunately no way to make a BuildRequires optional but will try to build each way.