### PR TITLE
Makefile audio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = g++
-CFLAGS += -std=c++11 -Wall -O3 -I/usr/include/speech_tools #-DAUDIO_MODE
-LIBS = -ljsoncpp -lcurl -lestools -lestbase -leststring -lasound -lncurses /usr/lib64/libFestival.a
+CFLAGS += -std=c++11 -Wall -O3 -I/usr/include/speech_tools
+LIBS = -ljsoncpp -lcurl -lestools -lestbase -leststring -lasound -lncurses
 SRC := $(wildcard *.cpp plugins/*.cpp) 
 HDR := $(wildcard *.h)
 OBJ := $(SRC:.cpp=.o)
@@ -11,7 +11,10 @@ all: aish
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 aish: $(OBJ)
-	$(CC) -o $@ $(CFLAGS) $(OBJ) $(LIBS)
+	$(CC) -DAUDIO_MODE -o $@ $(CFLAGS) $(OBJ) $(LIBS) /usr/lib64/libFestival.a
+
+aish_without_audio: $(OBJ)
+	$(CC) -o aish $(CFLAGS) $(OBJ) $(LIBS)
 
 debug: $(SRC) $(HDR)
 	$(CC) -o $@ $(CFLAGS) -g -DDEBUG $(SRC) $(LIBS)

--- a/dist/aish.srpm.spec
+++ b/dist/aish.srpm.spec
@@ -1,6 +1,4 @@
-# https://fedoraproject.org/wiki/How_to_create_an_RPM_package
-# Built and maintained by John Boero - boeroboy@gmail.com
-# In honor of Seth Vidal https://www.redhat.com/it/blog/thank-you-seth-vidal
+n# In honor of Seth Vidal https://www.redhat.com/it/blog/thank-you-seth-vidal
 
 Name:           aish
 Version:        0.2.2
@@ -8,6 +6,8 @@ Release:        1%{?dist}
 Summary:        AI shell is a CLI for AI to write and script in plain language.
 License:        MPL
 Source0:        https://github.com/brynzai/aish/archive/refs/tags/v%{version}.tar.gz
+
+#There is no weak BuildRequires, so use hacky (lib or glibc-devel)
 BuildRequires:  coreutils make jsoncpp-devel libcurl-devel gcc-c++ (festival-devel or glibc-devel) (alsa-lib-devel or glibc-devel) ncurses-devel
 Requires(post): libcurl jsoncpp
 URL:            https://www.github.com/brynzai/aish
@@ -25,7 +25,7 @@ this at your own risk and not in production. AI can produce unexpected results.
 
 %build
 # Try with AUDIO_MODE first. BuildRequires still fails if festivel-devel isn't available.
-CFLAGS="-DAUDIO_MODE" make -j || make -j
+make -j aish || make -j aish_without_audio
 
 %install
 mkdir -p %{buildroot}%{_bindir}/


### PR DESCRIPTION
Simplified Makefile and RPM Spec with two targets. First try to make with full audio support and libfestival statically linked. Otherwise fallback to make target aish_without_audio.