### PR TITLE
Forcing CFLAGS for build environment error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC		= g++
-CFLAGS		+= -std=c++11 -Wall -O3 -I/usr/include/speech_tools
+CFLAGS		= -std=c++11 -Wall -O3 -I/usr/include/speech_tools
 LIBS		= -ljsoncpp -lcurl
 LIBSAUDIO	= $(LIBS) -lestools -lestbase -leststring -lasound -lncurses /usr/lib64/libFestival.a
 SRC		:= $(wildcard *.cpp plugins/*.cpp)


### PR DESCRIPTION
COPR is setting extra CFLAGS that break the build, so set them here explicitly instead of adding.